### PR TITLE
Automatically update and release canary version to snapcraft store

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  # Runs every hour at 05 mins 
+  schedule:
+    - cron:  '5 * * * *'
+  push:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  get-architectures:
+    name: 🖥 Get snap architectures
+    runs-on: ubuntu-latest
+    outputs:
+      architectures: ${{ steps.get-architectures.outputs.architectures }}
+      architectures-list: ${{ steps.get-architectures.outputs.architectures-list }}
+    steps:
+      - name: 🖥 Get snap architectures
+        id: get-architectures
+        uses: snapcrafters/ci/get-architectures@main
+
+  release:
+    name: 🚢 Release to latest/candidate
+    needs: get-architectures
+    runs-on: ubuntu-latest
+    environment: "Master Branch"
+    strategy:
+      matrix:
+        architecture: ${{ fromJSON(needs.get-architectures.outputs.architectures-list) }}
+    steps:
+      - name: 🚢 Release to latest/candidate
+        uses: snapcrafters/ci/release-to-candidate@main
+        with:
+          architecture: ${{ matrix.architecture }}
+          launchpad-token: ${{ secrets.LP_BUILD_SECRET }}
+          repo-token: ${{ secrets.SNAPCRAFTERS_BOT_COMMIT }}
+          store-token: ${{ secrets.SNAP_STORE_CANDIDATE }}
+          
+  promote:
+    name: ⬆️ Promote to stable
+    environment: "Master Branch"
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⬆️ Promote to stable
+        uses: snapcrafters/ci/promote-to-stable@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          store-token: ${{ secrets.SNAP_STORE_STABLE }}

--- a/.github/workflows/version_updater.yml
+++ b/.github/workflows/version_updater.yml
@@ -1,0 +1,58 @@
+name: Update Canary version
+
+on:
+  # Runs every hour at 00 mins
+  schedule:
+    - cron:  '0 * * * *'
+  push:
+    branches: [ "master" ]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install beautifulsoup4
+
+      - name: Run get_latest_studio_url
+        id: studio_url
+        run: |
+          python -c "from snap.local.get_latest import get_latest_studio_url; version, url = get_latest_studio_url(); open('latest_url.txt', 'w').write(url); open('latest_version.txt', 'w').write(version)"
+
+      - name: Read new URL
+        id: read_url
+        run: echo "url=$(cat latest_url.txt)" >> $GITHUB_OUTPUT
+
+      - name: Read new Version
+        id: read_version
+        run: echo "version=$(cat latest_version.txt)" >> $GITHUB_OUTPUT
+
+      - name: Update url in snapcraft.yaml
+        run: |
+          sed -i "s|^\(\s*source:\s*\).*|\1${{ steps.read_url.outputs.url }}|" snap/snapcraft.yaml
+
+      - name: Update version in snapcraft.yaml
+        run: |
+          sed -i "s|^\(\s*version:\s*\).*|\1${{ steps.read_version.outputs.version }}|" snap/snapcraft.yaml
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add snap/snapcraft.yaml
+          git diff --cached --quiet || git commit -m "Update Snapcraft source URL"
+          git push origin master

--- a/snap/gui/android-studio-canary.desktop
+++ b/snap/gui/android-studio-canary.desktop
@@ -2,8 +2,8 @@
 Version=1.0
 Type=Application
 Name=Android Studio Canary
-Icon=/android-studio/bin/studio.png
-Exec="/android-studio/bin/studio.sh" %f
+Icon=${SNAP}/bin/studio.png
+Exec=android-studio-canary %f
 Comment=Android Studio Canary
 Categories=Development;IDE;
 Terminal=false

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: android-studio-canary
-adopt-info: android-studio-canary
+version: 2025.1.1.9
 summary: The IDE for Android (Canary build)
 description: |
   Android Studio provides the fastest tools for building apps on every type
@@ -8,7 +8,7 @@ description: |
   World-class code editing, debugging, performance tooling, a flexible build
   system, and an instant build/deploy system all allow you to focus on
   building unique and high quality apps.
-base: core18
+base: core22
 
 grade: stable
 confinement: classic
@@ -18,36 +18,13 @@ architectures:
 
 apps:
   android-studio-canary:
-    command: android-studio/bin/studio.sh
-    desktop: android-studio-canary.desktop
+    command: bin/studio.sh
+    environment:
+      PULSE_SERVER: $XDG_RUNTIME_DIR/pulse/native
 
 parts:
-  desktop:
-    plugin: dump
-    source: snap/local
-    prime:
-      - android-studio-canary.desktop
   android-studio-canary:
-    after: [desktop]
-    plugin: nil
-    override-build: |
-      snapcraftctl build
-      echo "Get latest release..."
-      RELEASE_INFO=$(python3 -u $SNAPCRAFT_STAGE/get_latest.py)
-
-      # Download
-      DOWNLOAD_URL=$(echo ${RELEASE_INFO} | cut -d ' ' -f2)
-      wget --quiet "${DOWNLOAD_URL}" -O "${SNAPCRAFT_PART_INSTALL}/android-studio.tgz"
-      tar zxvf "${SNAPCRAFT_PART_INSTALL}/android-studio.tgz" -C "${SNAPCRAFT_PART_INSTALL}"
-
-      # Cleanup
-      rm "${SNAPCRAFT_PART_INSTALL}/android-studio.tgz"
-
-      # Set version
-      snapcraftctl set-version $(echo $RELEASE_INFO | cut -d ' ' -f1)
-    build-packages:
-      - wget
-      - python3
-      - python3-bs4
+    plugin: dump
+    source: https://redirector.gvt1.com/edgedl/android/studio/ide-zips/2025.1.1.9/android-studio-2025.1.1.9-linux.tar.gz
     build-attributes:
       - no-patchelf


### PR DESCRIPTION
## Problem
The Android Studio Canary version has not been published to the Snapcraft store for some time.
Currently, the latest available version on [snapcraft.io/android-studio-canary](https://snapcraft.io/android-studio-canary) is 2023.2.1.7, while the latest upstream Canary version is 2025.1.1.9.

## Solution
I referenced code from [snapcrafters/android-studio](https://github.com/snapcrafters/android-studio) and updated the repository to help automate this publishing process.

## Changes Introduced
Added version_updater.yml: checks for new Canary releases hourly and updates the snapcraft.yaml file accordingly.

Added release.yml: builds and publishes the Snap to the Snapcraft store.

This follows Snapcraft’s recommended flow: first release to the candidate channel, then promote to stable.

## Notes
I'm new to Snapcraft and GitHub Actions but have tried to implement this as cleanly and reliably as possible.
The goal is to reduce manual effort and ensure timely updates of Canary releases to the store.

Also github actions do not trigger action based on commit made by bot, So I have set the timing as follows - 

- every hour at 00 mins version_updater.yml runs
- every hour at 05 mins release.yml runs 

## Testing
✅ version_updater.yml: Tested locally — it correctly fetches the latest version and updates the Snapcraft file.

⚠️ release.yml: Not tested end-to-end due to lack of publishing permissions.