### PR TITLE
docs: fix broken header image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <h1 align="center">
-  <img src="https://dashboard.snapcraft.io/site_media/appmedia/android-studio-canary.png" alt="Android Studio Canary">
+  <img src="https://developer.android.com/static/studio/images/android-studio-canary.svg" alt="Android Studio Canary" width="256" height="256">
+  <br />
+  Android Studio Canary
 </h1>
 
 <p align="center"><b>This is the snap for Android Studio Canary</b>. It is a community-maintained package to easily install Android Studio Canary on Ubuntu, Fedora, Debian and other major Linux distributions. It is available in the Snap Store, Ubuntu Software, and a number of other applications.</p>


### PR DESCRIPTION
## Problem

The header image in the README is broken. The URL it references:

```
https://dashboard.snapcraft.io/site_media/appmedia/android-studio-canary.png
```

Returns a **404 Not Found**.

## Fix

Replace it with the official **Android Studio Canary** icon served directly from Google's Android developer site:

```
https://developer.android.com/static/studio/images/android-studio-canary.svg
```

This is the correct Canary-specific icon — per the [2023 Android Studio logo redesign](https://android-developers.googleblog.com/2023/05/redesigning-android-studio-logo.html), Canary and Stable now use distinct icons: Canary uses an **outlined A**, Stable uses a **solid A**. Using this URL ensures we get the Canary variant, not the generic stable icon.

The change also adds an explicit snap title below the image and `width`/`height` attributes, matching the style used in the [snapcrafters/android-studio](https://github.com/snapcrafters/android-studio) README.